### PR TITLE
Add blog post: React's key prop

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,7 +7,6 @@ exports.createPages = ({ actions, graphql }) => {
     {
       allMarkdownRemark(
         sort: { order: DESC, fields: [frontmatter___date] }
-        limit: 1000
       ) {
         edges {
           node {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
     "react-helmet": "^5.2.0",
-    "react-markdown": "^4.0.3",
+    "react-markdown": "^3.6.0",
     "react-remarkbox": "^0.0.2",
     "recompose": "^0.30.0",
     "styled-components": "^4.0.2",

--- a/src/blog/2018-10-30-react-key-prop.md
+++ b/src/blog/2018-10-30-react-key-prop.md
@@ -1,0 +1,149 @@
+---
+title: "React's key prop"
+path: "/blog/react-key-prop"
+date: "2018-10-30"
+---
+
+
+In this post I'll talk a bit about React's `key` prop.
+The `key` is mostly known for being necessary to render lists,
+but there are other use cases as well.
+It can be a powerful thing that can be used to conjure some awesome
+React magics.
+
+
+## Lists
+
+
+The most common use for React's `key` prop is to render a list of elements.
+React uses it to track changes to the list items, like updates, insertions and removals.
+Without it, React wouldn't know if an element changed or was just moved
+in the list and would perform some unnecessary DOM changes.
+
+```jsx
+const Todos = ({ todos }) => (
+  <ul>
+    {todos.map(({ id, title }) => (
+      <li key={id}>
+        {text}
+      </li>
+    ))}
+  </ul>
+);
+```
+
+It's easy to be lazy about this and use the element's index as its `key`,
+but generally that isn't a good idea when items can be inserted on arbitrary
+positions, or when the order of the items can change.
+
+On the other hand, if the list being rendered never changes during runtime
+it's safe to use indexes.
+
+See the [official documentation](https://reactjs.org/docs/lists-and-keys.html)
+for more information on lists and keys.
+
+
+## Forcing remounts
+
+
+Another thing keys can be used for is to force a component to unmount and mount again.
+This means that the mounting lifecycle methods (like `componentDidMount`)
+will be called.
+There are a few interesting use cases where you might want to do this.
+
+
+### Refetching data
+
+
+Forcing a component to remount can be useful if you have a component that
+fetches data when mounting and you want to force it to fetch that data again.
+
+Imagine a `UserDetails` component that fetches the user's data when it mounts:
+
+```jsx
+class UserDetails extends Component {
+  componentDidMount() {
+    this.props.fetchUser();
+  }
+
+  render() {
+    // ...
+  }
+}
+```
+
+If for some reason you want to fetch the user's data again, you have two options:
+
+- You can pass a prop to `UserDetails` telling it to fetch again and handle it on `componentDidUpdate`;
+- Pass a `key` prop to `UserDetails` and change it when you want to re-fetch.
+
+The second option would look like this:
+
+```jsx
+class UserPage extends Component {
+  state = { userDetailsKey: 0 };
+
+  refresh = () => {
+    this.setState(({ userDetailsKey }) => ({
+      userDetailsKey: userDetailsKey + 1
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <UserDetails key={this.state.userDetailsKey} />
+        <button onClick={this.refresh}>
+          Refresh
+        </button>
+      </div>
+    );
+  }
+}
+```
+
+When the "Refresh" button is clicked, `userDetailsKey` will be incremented,
+changing `UserDetails`'s `key`.
+React will then unmount the current instance of `UserDetails` and mount
+a new one.
+
+
+### Animations
+
+
+This technique can also be useful for animations.
+React will unmount elements when their keys change and mount them again.
+This will make CSS animations trigger again.
+
+Here's an example:
+
+<iframe
+  allowfullscreen='true'
+  allowtransparency='true'
+  frameborder='no'
+  height='300'
+  scrolling='no'
+  src='//codepen.io/bsonntag/embed/JmqVwB/?height=300&theme-id=0&default-tab=js,result'
+  style='width: 100%;'
+  title='Ripple effect using React key'
+>
+See the Pen
+<a href='https://codepen.io/bsonntag/pen/JmqVwB/' target='_blank' rel='noopener'>Ripple effect using React key</a>
+by Benjamim Sonntag
+(<a href='https://codepen.io/bsonntag' target='_blank' rel='noopener'>@bsonntag</a>)
+on <a href='https://codepen.io' target='_blank' rel='noopener'>CodePen</a>.
+</iframe>
+
+On this example I have a button with a ripple effect which is triggered when the button is clicked.
+This is done by incrementing a `key` stored in the `Button` component's state
+when the button is clicked.
+Changing this `key` will make the button element remount,
+triggering the animation again.
+
+
+## More ideas?
+
+
+If you know about some other interesing uses of the `key` prop
+please share them below on the comments.
+I always love to hear about new React tricks.

--- a/src/components/home/blog.js
+++ b/src/components/home/blog.js
@@ -1,14 +1,20 @@
 import { Link } from 'gatsby';
+import { margin } from 'styles/spacing';
 import { renderDate } from 'utils/date';
 import React from 'react';
 import Type from 'components/type';
+import styled from 'styled-components';
+
+const PostTitle = styled(Type.subheading)`
+  ${margin.bottom('none')}
+`;
 
 const Blog = ({ posts }) => posts.map(post => (
   <div key={post.id}>
     <Link to={post.url}>
-      <Type.subheading>
+      <PostTitle>
         {post.title}
-      </Type.subheading>
+      </PostTitle>
     </Link>
 
     <Type.paragraph>

--- a/src/components/markdown/code-block.js
+++ b/src/components/markdown/code-block.js
@@ -7,6 +7,7 @@ import {
 } from 'styles';
 
 import { highlightCode } from 'utils/code';
+import { renderInnerHtml } from 'utils/html';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -25,10 +26,6 @@ const Pre = styled.pre`
 const Code = styled.code`
   ${codeStyle}
 `;
-
-const renderInnerHtml = html => ({
-  __html: html, // eslint-disable-line id-match
-});
 
 const CodeBlock = ({ language, value }) => (
   <Pre>

--- a/src/components/markdown/html.js
+++ b/src/components/markdown/html.js
@@ -1,0 +1,16 @@
+import { margin } from 'styles/spacing';
+import { renderInnerHtml } from 'utils/html';
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  max-width: 100%;
+
+  ${margin.vertical('small')}
+`;
+
+const Html = ({ value }) => (
+  <Wrapper dangerouslySetInnerHTML={renderInnerHtml(value)} />
+);
+
+export default Html;

--- a/src/components/markdown/index.js
+++ b/src/components/markdown/index.js
@@ -3,6 +3,7 @@ import { Fragment } from 'react';
 import { withProps } from 'recompose';
 import CodeBlock from './code-block';
 import Heading from './heading';
+import Html from './html';
 import InlineCode from './inline-code';
 import Markdown from 'react-markdown';
 import Type from 'components/type';
@@ -10,6 +11,7 @@ import Type from 'components/type';
 const renderers = {
   code: CodeBlock,
   heading: Heading,
+  html: Html,
   inlineCode: InlineCode,
   link: ExternalLink,
   paragraph: Type.paragraph,

--- a/src/components/type.js
+++ b/src/components/type.js
@@ -1,5 +1,6 @@
 import { createTypeStyle, typography } from 'styles';
 import { reduce } from 'lodash';
+import { renderInnerHtml } from 'utils/html';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -11,11 +12,9 @@ const createTypeComponent = (name, { element, ...typeConfig }) => {
   const Type = ({ children, raw, ...rest }) => {
     const props = {
       ...rest,
-      ...raw ? {
-        dangerouslySetInnerHTML: {
-          __html: children, // eslint-disable-line id-match
-        },
-      } : { children },
+      ...!raw ? { children } : {
+        dangerouslySetInnerHTML: renderInnerHtml(children),
+      },
     };
 
     return <StyledTypeElement {...props} />;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,7 +52,7 @@ const Home = ({ data }) => {
 
 export const query = graphql`
   query {
-    allMarkdownRemark {
+    allMarkdownRemark(sort: { order: DESC, fields: [frontmatter___date] }) {
       totalCount
       edges {
         node {

--- a/src/styles/spacing.test.js
+++ b/src/styles/spacing.test.js
@@ -21,6 +21,19 @@ describe('spacing', () => {
       expect(foo('bar')).toEqual(expected);
     });
 
+    it('should create spacings creators for each specified property name', () => {
+      const foo = createSpacing(['foo', 'bar'], {
+        baz: { base: '1px' },
+      });
+
+      const expected = expect.arrayContaining([
+        'foo: 1px;',
+        'bar: 1px;',
+      ]);
+
+      expect(foo('baz')).toEqual(expected);
+    });
+
     it('should create spacings creators that accept custom values', () => {
       const foo = createSpacing(['foo'], {});
 

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -1,0 +1,3 @@
+export const renderInnerHtml = html => ({
+  __html: html, // eslint-disable-line id-match
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,11 +1307,6 @@ aria-query@^3.0.0:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
 
-arity-n@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
-  integrity sha1-2edrEXM+CFacCEeuezmyhgswt0U=
-
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -2854,11 +2849,6 @@ cheerio@^1.0.0-rc.2:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chickencurry@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/chickencurry/-/chickencurry-1.1.1.tgz#02655f2b26b3bc2ee1ae1e5316886de38eb79738"
-  integrity sha1-AmVfKyazvC7hrh5TFoht4463lzg=
-
 chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -3158,13 +3148,6 @@ component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
   integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
-
-compose-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/compose-function/-/compose-function-2.0.0.tgz#e642fa7e1da21529720031476776fc24691ac0b0"
-  integrity sha1-5kL6fh2iFSlyADFHZ3b8JGkawLA=
-  dependencies:
-    arity-n "^1.0.4"
 
 compressible@~2.0.14:
   version "2.0.15"
@@ -6830,23 +6813,12 @@ html-entities@^1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
 
-html-to-react@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.3.3.tgz#e41666a735f9997ed2372dcd21d8b0e42b334467"
-  integrity sha512-4Qi5/t8oBr6c1t1kBJKyxEeJu0lb7ctvq29oFZioiUHH0Wz88VWGwoXuH26HDt9v64bDHA4NMPNTH8bVrcaJWA==
-  dependencies:
-    domhandler "^2.3.0"
-    escape-string-regexp "^1.0.5"
-    htmlparser2 "^3.8.3"
-    ramda "^0.25.0"
-    underscore.string.fp "^1.0.4"
-
 html-void-elements@^1.0.0, html-void-elements@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.3.tgz#956707dbecd10cf658c92c5d27fee763aa6aa982"
   integrity sha512-SaGhCDPXJVNrQyKMtKy24q6IMdXg5FCPN3z+xizxw9l+oXQw5fOoaj/ERU5KqWhSYhXtW5bWthlDbTDLBhJQrA==
 
-htmlparser2@^3.8.3, htmlparser2@^3.9.0, htmlparser2@^3.9.1:
+htmlparser2@^3.9.0, htmlparser2@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
   integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
@@ -11178,12 +11150,11 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-markdown@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.0.3.tgz#8851f9265d0322bb5d60ab2766b3ab48cdbeb890"
-  integrity sha512-CIc3eLVpW5XocM1MCid2rS0vs9skhvdL/slAkY/a3Cr9y72b0J/25GiD70fGmStjuxsd5ROdm4ZYfiYYxPPyGA==
+react-markdown@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.6.0.tgz#29f6aaab5270c8ef0a5e234093a873ec3e01722b"
+  integrity sha512-TV0wQDHHPCEeKJHWXFfEAKJ8uSEsJ9LgrMERkXx05WV/3q6Ig+59KDNaTmjcoqlCpE/sH5PqqLMh4t0QWKrJ8Q==
   dependencies:
-    html-to-react "^1.3.3"
     mdast-add-list-metadata "1.0.1"
     prop-types "^15.6.1"
     remark-parse "^5.0.0"
@@ -11784,11 +11755,6 @@ retext-english@^3.0.0:
   dependencies:
     parse-english "^4.0.0"
     unherit "^1.0.4"
-
-reverse-arguments@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/reverse-arguments/-/reverse-arguments-1.0.0.tgz#c28095a3a921ac715d61834ddece9027992667cd"
-  integrity sha1-woCVo6khrHFdYYNN3s6QJ5kmZ80=
 
 rgb-regex@^1.0.1:
   version "1.0.1"
@@ -13418,21 +13384,6 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
-
-underscore.string.fp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/underscore.string.fp/-/underscore.string.fp-1.0.4.tgz#054b3f1843bcae561286c87de5e8879b4fc98364"
-  integrity sha1-BUs/GEO8rlYShsh95eiHm0/Jg2Q=
-  dependencies:
-    chickencurry "1.1.1"
-    compose-function "^2.0.0"
-    reverse-arguments "1.0.0"
-    underscore.string "3.0.3"
-
-underscore.string@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.0.3.tgz#4617b8c1a250cf6e5064fbbb363d0fa96cf14552"
-  integrity sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI=
 
 underscore.string@^3.3.4:
   version "3.3.5"


### PR DESCRIPTION
This adds the "React's key prop" blog post.

This also downgrades the `react-markdown` dependency to version 3.6.0 to fix a bug on title anchors and adds support for HTML in markdown.