### PR TITLE
Fix scalling effect of social network links

### DIFF
--- a/src/components/social-networks.js
+++ b/src/components/social-networks.js
@@ -19,9 +19,10 @@ const socialNetworks = [{
 }];
 
 const ScallingLink = styled(ExternalLink)`
+  display: block;
   transition: transform 200ms ease-in-out;
 
-  &:hover {
+  &:focus, &:hover {
     transform: scale(1.2);
   }
 `;


### PR DESCRIPTION
This PR fixes the hover style of the social network links. This was necessary because the anchor elements became inline elements on #17 and transforms don't work on inline elements.

This also makes the scalling effect happen on focus as well.